### PR TITLE
Update with solution to activity recreation

### DIFF
--- a/app/src/main/java/com/example/composetest/MainActivity.kt
+++ b/app/src/main/java/com/example/composetest/MainActivity.kt
@@ -9,9 +9,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.composetest.ui.theme.ComposeTestTheme
 
@@ -22,7 +20,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val viewModel: MainViewModel = viewModel()
 
-            val launcher = statefulLauncher(viewModel::fetch)
+            val launcher = statefulLauncher(key = "fetch", viewModel::fetch)
 
             ComposeTestTheme {
                 // A surface container using the 'background' color from the theme
@@ -30,33 +28,19 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    Greeting("Android")
-                }
 
-                Column {
-                    Text(text = "isRunning: ${launcher.isRunning}")
+                    Column {
+                        Text(text = "isRunning: ${launcher.isRunning}")
 
-                    Button(
-                        enabled = !launcher.isRunning.value,
-                        onClick = { launcher() }
-                    ) {
-                        Text(text = "Fetch!")
+                        Button(
+                            enabled = !launcher.isRunning.value,
+                            onClick = { launcher() }
+                        ) {
+                            Text(text = "Fetch!")
+                        }
                     }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    ComposeTestTheme {
-        Greeting("Android")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Sep 06 17:29:39 PDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id 'com.android.application' version '7.1.0-alpha10'
-        id 'com.android.library' version '7.1.0-alpha10'
+        id 'com.android.application' version '7.1.0-alpha11'
+        id 'com.android.library' version '7.1.0-alpha11'
         id 'org.jetbrains.kotlin.android' version '1.5.10'
     }
 }


### PR DESCRIPTION
Sorry for the low PR hygiene.

Main thought behind this is we can kick the `MutableStateFlow` into a `ViewModel` without forcing it to be reimplemented for every view model.

Left the `key` as `Any` to keep things flexible. As an example of when that would be useful, if the buttons are part of a `LazyColumn` you might want to use the backing data structure as part of the key to get per-item statefulness. 

As an aside, this also opens things up to allowing two different stateful launchers to share the same count. Might want to disable all buttons when any one is running, or something.